### PR TITLE
Default unit_valid_slot as true

### DIFF
--- a/plugins/sync_status/functions/fn_postStatus.sqf
+++ b/plugins/sync_status/functions/fn_postStatus.sqf
@@ -5,7 +5,7 @@ _unit = _this select 0;
 _uid = _this select 2;
 _name = _this select 3;
 
-_validSlot = _unit getVariable ["unit_valid_slot", false];
+_validSlot = _unit getVariable ["unit_valid_slot", true];
 
 if ([_uid, _name] in mission_dead_players) exitWith {};
 if (!_validSlot) exitWith {};


### PR DESCRIPTION
Quitting the game without the unit_valid_slot set at all won't save status, (prevent_reslot plugin disabled)