### PR TITLE
Spectator Respawn Quickfix

### DIFF
--- a/engine/events/fn_endSpectator.sqf
+++ b/engine/events/fn_endSpectator.sqf
@@ -16,6 +16,7 @@
 
     if (mission_TFAR_enabled) then {
         _this setVariable ["tf_unable_to_use_radio", false];
+        [_this, false] call TFAR_fnc_forceSpectator;
     };
 
     titletext ["You are respawning...", "BLACK FADED",0];


### PR DESCRIPTION
Quickfix for player's still being considered spectating by TFAR when respawned.