### PR TITLE
Fix Friendly Fire script error when a player is killed

### DIFF
--- a/plugins/friendly_fire/functions/fn_postinit.sqf
+++ b/plugins/friendly_fire/functions/fn_postinit.sqf
@@ -1,5 +1,3 @@
 if !(hasInterface) exitWith {};
 
 player addEventHandler ["Hit", BRM_FMK_FriendlyFire_fnc_alert];
-
-player addEventHandler ["Killed", BRM_FMK_FriendlyFire_fnc_alert];


### PR DESCRIPTION
The Killed event handler would have never caused a message to be sent before the `instigator` addition, since the `_damage` would have been nil, which would have caused the script to halt execution.