### PR TITLE
Heroes loadout patch3

### DIFF
--- a/loadouts/cargo-list.sqf
+++ b/loadouts/cargo-list.sqf
@@ -123,4 +123,12 @@ switch(_x) do {
             [_parachute , 15]
         ]] call BRM_FMK_fnc_addtoCargo;
     };
+    
+    case "rifle_grenades": {
+       [[_object, "item",
+            ["R3F_APAV40", 40],
+            ["R3F_AC58", 40],
+            ["R3F_FUM40", 40]
+        ]] call BRM_FMK_fnc_addtoCargo;
+    };
 };

--- a/loadouts/factions/frdesert.sqf
+++ b/loadouts/factions/frdesert.sqf
@@ -21,8 +21,8 @@ _factionSkill = [[0.7,0.8],   [0.8,0.9],      [0.7,0.8],     [0.7,0.9],      [0.
 
 // WEAPONS =====================================================================
 
-_commonRIFLE            = _FAMASG2Desert;
-_commonRIFLEGL          = _FAMASG2DesertGL;
+_commonRIFLE            = ["R3F_Famas_G2_HG_DES","30Rnd_556x45_Stanag"];
+_commonRIFLEGL          = ["R3F_Famas_G2_M203_DES","30Rnd_556x45_Stanag","1Rnd_HE_Grenade_shell"];
 _commonPISTOL           = ["R3F_PAMAS","R3F_15Rnd_9x19_PAMAS"];
 _commonAR               = _FNMINIMIRIS;
 _commonMG               = _M240G;


### PR DESCRIPTION
changed ammo type for FAMAS in FRDESERT loadout ( now compatible with recon weapons ), added rifle grenades ammo to cargo-list ( mission maker will have to add the option in the crate like for AT, medical, radio ... )