### PR TITLE
Adding spotting round mags to units that spawn with the SMAW

### DIFF
--- a/loadouts/factions/structures/afrenian_army.sqf
+++ b/loadouts/factions/structures/afrenian_army.sqf
@@ -97,6 +97,7 @@ switch (true) do {
         [_unit, [[_specAT select RAMMO, _countAT] ]] call BRM_FMK_fnc_addtoBackpack;
         [_unit, _specAT select GUN, 1, ["HE"]] call BRM_FMK_fnc_addAmmoAuto;
         [_unit, "secondary", "rhs_weap_optic_smaw"] call BRM_FMK_fnc_attachToWeapon;
+        if (_specAT == _SMAW) then {[_unit, "rhs_mag_smaw_SR", 3] call BRM_FMK_fnc_addAmmo};
     };
 
     case (_isWeaponsAT): {
@@ -237,6 +238,7 @@ switch (true) do {
         [_unit, [[_specAT select RAMMO, _countAT] ]] call BRM_FMK_fnc_addtoBackpack;
         [_unit, _specAT select GUN, 1, ["HE"]] call BRM_FMK_fnc_addAmmoAuto;
         [_unit, "primary", _commonSUPPRESSOR] call BRM_FMK_fnc_attachToWeapon;
+        if (_specAT == _SMAW) then {[_unit, "rhs_mag_smaw_SR", 3] call BRM_FMK_fnc_addAmmo};
     };
     
      case (_isReconMarksman ): {

--- a/loadouts/factions/structures/frastruct.sqf
+++ b/loadouts/factions/structures/frastruct.sqf
@@ -107,6 +107,7 @@ switch (true) do {
         [_unit, _specAT select RAMMO, 1, ["HE"]] call BRM_FMK_fnc_addAmmoAuto;
         [_unit, "primary", _commonCCO] call BRM_FMK_fnc_attachToWeapon;
         [_unit, "primary", "R3F_PIRAT"] call BRM_FMK_fnc_attachToWeapon;
+        if (_specAT == _SMAW) then {[_unit, "rhs_mag_smaw_SR", 3] call BRM_FMK_fnc_addAmmo};
     };
 
     case (_isWeaponsAT): {
@@ -286,6 +287,7 @@ switch (true) do {
         [_unit, "primary", _commonSUPPRESSOR] call BRM_FMK_fnc_attachToWeapon;
         [_unit, "primary","rhsusf_acc_SpecterDR_3d"] call BRM_FMK_fnc_attachToWeapon;
         [_unit, "primary", "rhsusf_acc_anpeq15side_bk"] call BRM_FMK_fnc_attachToWeapon;
+        if (_specAT == _SMAW) then {[_unit, "rhs_mag_smaw_SR", 3] call BRM_FMK_fnc_addAmmo};
     };
     
      case (_isReconMarksman ): {

--- a/loadouts/factions/structures/high_tier_army.sqf
+++ b/loadouts/factions/structures/high_tier_army.sqf
@@ -118,6 +118,7 @@ switch (true) do {
 #ifdef STRUCTURE_RIFLEMAN_CCO
         [_unit, "primary", _commonCCO] call BRM_FMK_fnc_attachToWeapon;
 #endif
+        if (_specAT == _SMAW) then {[_unit, "rhs_mag_smaw_SR", 3] call BRM_FMK_fnc_addAmmo};
     };
 
     case (_isWeaponsATAssistant): {
@@ -303,6 +304,7 @@ switch (true) do {
         [_unit, [[_specAT select RAMMO, _countAT] ]] call BRM_FMK_fnc_addtoBackpack;
         [_unit, _specAT select GUN, 1, ["HE"]] call BRM_FMK_fnc_addAmmoAuto;
         [_unit, "primary", _commonSUPPRESSOR] call BRM_FMK_fnc_attachToWeapon;
+        if (_specAT == _SMAW) then {[_unit, "rhs_mag_smaw_SR", 3] call BRM_FMK_fnc_addAmmo};
     };
     
      case (_isReconMarksman ): {

--- a/loadouts/factions/structures/low_tier_army.sqf
+++ b/loadouts/factions/structures/low_tier_army.sqf
@@ -91,6 +91,7 @@ switch (true) do {
         [_unit, _specAT] call BRM_FMK_fnc_addWeapon;
         [_unit, [[_specAT select RAMMO, _countAT] ]] call BRM_FMK_fnc_addtoBackpack;
         [_unit, _specAT select GUN, 1, ["HE"]] call BRM_FMK_fnc_addAmmoAuto;
+        if (_specAT == _SMAW) then {[_unit, "rhs_mag_smaw_SR", 3] call BRM_FMK_fnc_addAmmo};
     };
 
     case (_isWeaponsAT): {
@@ -229,6 +230,7 @@ switch (true) do {
         [_unit, [[_specAT select RAMMO, _countAT] ]] call BRM_FMK_fnc_addtoBackpack;
         [_unit, _specAT select GUN, 1, ["HE"]] call BRM_FMK_fnc_addAmmoAuto;
         [_unit, "primary", _commonSUPPRESSOR] call BRM_FMK_fnc_attachToWeapon;
+        if (_specAT == _SMAW) then {[_unit, "rhs_mag_smaw_SR", 3] call BRM_FMK_fnc_addAmmo};
     };
     
      case (_isReconMarksman ): {

--- a/loadouts/factions/structures/mid_tier_army.sqf
+++ b/loadouts/factions/structures/mid_tier_army.sqf
@@ -94,6 +94,7 @@ switch (true) do {
         [_unit, _specAT] call BRM_FMK_fnc_addWeapon;
         [_unit, [[_specAT select RAMMO, _countAT] ]] call BRM_FMK_fnc_addtoBackpack;
         [_unit, _specAT select GUN, 1, ["HE"]] call BRM_FMK_fnc_addAmmoAuto;
+        if (_specAT == _SMAW) then {[_unit, "rhs_mag_smaw_SR", 3] call BRM_FMK_fnc_addAmmo};
     };
 
     case (_isWeaponsAT): {
@@ -234,6 +235,7 @@ switch (true) do {
         [_unit, [[_specAT select RAMMO, _countAT] ]] call BRM_FMK_fnc_addtoBackpack;
         [_unit, _specAT select GUN, 1, ["HE"]] call BRM_FMK_fnc_addAmmoAuto;
         [_unit, "primary", _commonSUPPRESSOR] call BRM_FMK_fnc_attachToWeapon;
+        if (_specAT == _SMAW) then {[_unit, "rhs_mag_smaw_SR", 3] call BRM_FMK_fnc_addAmmo};
     };
     
      case (_isReconMarksman ): {


### PR DESCRIPTION
For the units that are assigned **_specAT** evaluates if **_specAT** is the SMAW and in that case adds three mags of spotting rounds (should be a sufficient amount).  Not applied to the German structure since I'm pretty sure they don't use SMAW (this in the interest of not bloating). 